### PR TITLE
Adding ability to pass init scripts to the server

### DIFF
--- a/financial_game/__main__.py
+++ b/financial_game/__main__.py
@@ -4,14 +4,71 @@
     Main entrypoint to the game
 """
 
+
+import argparse
+import os
+import sys
+
 import financial_game.webserver
+
+
+DEFAULT_DATABASE = "objects/test.sqlite3"
+DEFAULT_WEB_PORT = 8000
+
+
+def parse_command_line():
+    """Parses command line options"""
+    parser = argparse.ArgumentParser(description="A web-based real-life financial game")
+    parser.add_argument(
+        "-p",
+        "--port",
+        dest="port",
+        type=int,
+        default=DEFAULT_WEB_PORT,
+        help="The port the web server listens on",
+    )
+    parser.add_argument(
+        "-d",
+        "--db",
+        dest="database",
+        type=str,
+        default=DEFAULT_DATABASE,
+        help="SqlAlchemy URL for the database or path to Sqlite3 database",
+    )
+    parser.add_argument(
+        "--debug", dest="debug", action="store_true", help="Should we be debugging"
+    )
+    parser.add_argument(
+        "--reset",
+        dest="reset",
+        type=str,
+        help="Path to a yaml script to (re)initialize the database "
+        + "(only valid if db is a file path or db is empty)",
+    )
+    args = parser.parse_args()
+
+    if "://" not in args.database:
+
+        if args.reset:
+            if not os.path.isfile(args.reset):
+                parser.print_help()
+                print(f"Reset file not found: {args.reset}")
+                sys.exit(1)
+
+            if os.path.isfile(args.database):
+                os.unlink(args.database)
+
+        args.database = f"sqlite:///{args.database}"
+
+    return args
 
 
 def main():
     """main entrypoint"""
-    database = financial_game.model.Database("sqlite:///objects/test.sqlite3")
+    args = parse_command_line()
+    database = financial_game.model.Database(args.database, serialized=args.reset)
     app = financial_game.webserver.create_app(database)
-    app.run(host="0.0.0.0", debug=True, port=8000)
+    app.run(host="0.0.0.0", debug=args.debug, port=args.port)
 
 
 if __name__ == "__main__":

--- a/initial_db.yaml
+++ b/initial_db.yaml
@@ -1,0 +1,11 @@
+users:
+    1:
+        name: John
+        email: john.appleseed@apple.com
+        password: Setec astronomy
+        sponsor_id: null
+    2:
+        name: Jane
+        email: Jane.Doe@apple.com
+        password: too many secrets
+        sponsor_id: 1

--- a/pr_build.sh
+++ b/pr_build.sh
@@ -9,6 +9,11 @@
 
 export MINIMUM_TEST_COVERAGE=100
 export SOURCE_DIR=financial_game
+export RUN_DATABASE=objects/test.sqlite3
+export RUN_PORT=8000
+export RUN_DEBUG=--debug
+export RUN_RESET_SCRIPT=initial_db.yaml
+export RUN_ARGS="--port $RUN_PORT --db $RUN_DATABASE $RUN_DEBUG --reset $RUN_RESET_SCRIPT"
 export SOURCES="$SOURCE_DIR/*.py"
 export VENV_DIR=.venv
 export REQUIREMENTS_PATH=requirements.txt
@@ -155,7 +160,7 @@ fi
 #
 #####################################
 
-if [ "$1" = "run" ]; then python3 -m $SOURCE_DIR --test; fi
+if [ "$1" = "run" ]; then python3 -m $SOURCE_DIR $RUN_ARGS; fi
 
 
 #####################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest==7.2.0
 coverage==7.0.3
 typing-extensions
 Mako==1.2.4
+PyYAML==6.0

--- a/tests/model.yaml
+++ b/tests/model.yaml
@@ -1,0 +1,11 @@
+users:
+    1:
+        name: John
+        email: john.appleseed@apple.com
+        password: Setec astronomy
+        sponsor_id: null
+    2:
+        name: Jane
+        email: Jane.Doe@apple.com
+        password: too many secrets
+        sponsor_id: 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
 import tempfile
+import os
 
 import financial_game.model
+
+
+TEST_YAML_PATH = os.path.join(os.path.split(__file__)[0], "model.yaml")
 
 
 def test_user():
@@ -97,7 +101,7 @@ def test_serialize():
         db.flush()
         db.close()
 
-        db = financial_game.model.Database("sqlite:///" + workspace + "test3.sqlite3", serialized)
+        db = financial_game.model.Database("sqlite:///" + workspace + "test3.sqlite3", TEST_YAML_PATH)
 
         users = db.get_users()
         assert db.count_users() == 2, "users = {db.count_users()}"


### PR DESCRIPTION
Added several command line options:

usage: \_\_main\_\_.py [-h] [-p PORT] [-d DATABASE] [--debug] [--reset RESET]

A web-based real-life financial game

optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT  The port the web server listens on
  -d DATABASE, --db DATABASE SqlAlchemy URL for the database or path to Sqlite3 database
  --debug               Should we be debugging
  --reset RESET         Path to a yaml script to (re)initialize the database (only valid if db is a file path or db is empty)
