### PR TITLE
Adding a settings file, which the command line can override

### DIFF
--- a/financial_game/settings.py
+++ b/financial_game/settings.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+""" Handles settings file
+"""
+
+
+import os
+
+import yaml
+
+
+DEFAULT_DATABASE = "objects/test.sqlite3"
+DEFAULT_WEB_PORT = 8000
+
+# TODO: Get the correct path on each platform (dict)  # pylint: disable=fixme
+DEFAULT_SETTINGS = os.path.join(
+    os.environ["HOME"], "Library", "Preferences", "financial_game.yaml"
+)
+
+
+def default_path():
+    """Get the default path for the settings file"""
+    return DEFAULT_SETTINGS
+
+
+def load(args):
+    """Fill in unset args with either default or values from settings file"""
+    if args.settings is None:
+        args.settings = default_path()
+
+    try:
+        with open(args.settings, "r", encoding="utf-8") as settings_file:
+            settings = yaml.safe_load(settings_file.read())
+
+    except FileNotFoundError:
+        settings = {}
+
+    args.port = (
+        settings.get("port", DEFAULT_WEB_PORT) if args.port is None else args.port
+    )
+    args.database = (
+        settings.get("database", DEFAULT_DATABASE)
+        if args.database is None
+        else args.database
+    )
+    args.secret = (
+        settings.get("secret", args.secret) if args.secret is None else args.secret
+    )
+    args.debug = settings.get("debug", args.debug) if not args.debug else args.debug
+    args.reset = settings.get("reset", args.reset) if args.reset is None else args.reset
+
+    if args.secret is None and not os.path.isfile(args.settings):
+        write(
+            args.settings,
+            {
+                "port": args.port,
+                "database": args.database,
+                "secret": args.secret,
+                "debug": args.debug,
+                "reset": args.reset,
+            },
+        )
+
+    return args
+
+
+def write(path, settings):
+    """Creates the file and writes the settings"""
+    os.makedirs(os.path.split(path)[0], exist_ok=True)
+
+    with open(path, "w", encoding="utf-8") as settings_file:
+        yaml.dump(settings, settings_file)

--- a/financial_game/webserver.py
+++ b/financial_game/webserver.py
@@ -15,7 +15,7 @@ import financial_game.sessionkey
 SECRET = "secret"
 
 
-def create_app(database):
+def create_app(database, args):
     """create the flask app"""
     app = flask.Flask(__name__)
 
@@ -29,7 +29,7 @@ def create_app(database):
             user_id, password_hash = financial_game.sessionkey.parse(
                 flask.request.cookies[financial_game.sessionkey.COOKIE],
                 flask.request.headers,
-                SECRET,
+                args.secret,
             )
             user = database.get_user(user_id)
 
@@ -62,7 +62,7 @@ def create_app(database):
         if user and user.password_matches(flask.request.form["password"]):
             response = flask.make_response(flask.redirect(flask.url_for("home")))
             session_key = financial_game.sessionkey.create(
-                user, flask.request.headers, SECRET
+                user, flask.request.headers, args.secret
             )
             response.set_cookie(financial_game.sessionkey.COOKIE, session_key)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+
+import types
+import tempfile
+import os
+
+import financial_game.settings
+
+
+def test_basics():
+    with tempfile.TemporaryDirectory() as workspace:
+        old_settings = financial_game.settings.DEFAULT_SETTINGS
+        financial_game.settings.DEFAULT_SETTINGS = os.path.join(workspace, "test.yaml")
+        args = financial_game.settings.load(types.SimpleNamespace(
+            port=80,
+            database="objects/testing_more.sqlite3",
+            secret='secret',
+            debug=True,
+            settings=financial_game.settings.DEFAULT_SETTINGS,
+            reset="reset_file.yaml"
+        ))
+        assert not os.path.isfile(financial_game.settings.DEFAULT_SETTINGS)
+        assert args.port == 80, args.port
+        assert args.database == "objects/testing_more.sqlite3", args.database
+        assert args.secret == "secret", args.secret
+        assert args.debug, args.debug
+        assert args.reset == "reset_file.yaml", args.reset
+        financial_game.settings.DEFAULT_SETTINGS = old_settings
+
+
+def test_no_secrets():
+    with tempfile.TemporaryDirectory() as workspace:
+        old_settings = financial_game.settings.DEFAULT_SETTINGS
+        financial_game.settings.DEFAULT_SETTINGS = os.path.join(workspace, "test.yaml")
+        args = financial_game.settings.load(types.SimpleNamespace(
+            port=80,
+            database="objects/testing_more.sqlite3",
+            secret=None,
+            debug=True,
+            settings=financial_game.settings.DEFAULT_SETTINGS,
+            reset="reset_file.yaml"
+        ))
+        assert os.path.isfile(financial_game.settings.DEFAULT_SETTINGS)
+        assert args.port == 80, args.port
+        assert args.database == "objects/testing_more.sqlite3", args.database
+        assert args.secret is None, args.secret
+        assert args.debug, args.debug
+        assert args.reset == "reset_file.yaml", args.reset
+        financial_game.settings.DEFAULT_SETTINGS = old_settings
+
+
+def test_override():
+    with tempfile.TemporaryDirectory() as workspace:
+        old_settings = financial_game.settings.DEFAULT_SETTINGS
+        financial_game.settings.DEFAULT_SETTINGS = os.path.join(workspace, "test.yaml")
+        args = financial_game.settings.load(types.SimpleNamespace(
+            port=80,
+            database="objects/testing_more.sqlite3",
+            secret=None,
+            debug=False,
+            settings=None,
+            reset="reset_file.yaml"
+        ))
+        assert args.secret is None, args.secret
+        assert os.path.isfile(financial_game.settings.DEFAULT_SETTINGS)
+        assert not args.debug, args.debug
+        args = financial_game.settings.load(types.SimpleNamespace(
+            port=800,
+            database="objects/testing_some_more.sqlite3",
+            secret=None,
+            debug=True,
+            settings=None,
+            reset="reset_file_release.yaml"
+        ))
+        assert args.port == 800, args.port
+        assert args.database == "objects/testing_some_more.sqlite3", args.database
+        assert args.secret is None, args.secret
+        assert args.debug, args.debug
+        assert args.reset == "reset_file_release.yaml", args.reset
+        financial_game.settings.DEFAULT_SETTINGS = old_settings
+
+
+if __name__ == "__main__":
+    test_basics()
+    test_no_secrets()
+    test_override()


### PR DESCRIPTION
With this change you can either pass a settings file or use the default settings file.

Command line options default to the settings file values if not specified on the command line, with the exception of:

- **--settings** which is not specified in the settings file and if not set defaults to a system specific value
- **--debug** which if either the file or command line is **true** then it will be debug